### PR TITLE
fix: allow vinkla/hashids v14 for Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "laravel/framework": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "laravel/pint": "^1.14",
         "ramsey/uuid": "^4.7",
-        "vinkla/hashids": "^13.0.0"
+        "vinkla/hashids": "^13.0.0|^14.0.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
## Problem

PR #14 added `laravel/framework: ^13.0` support, but left `vinkla/hashids` constrained to `^13.0.0`. Since `^13.0.0` resolves to `>=13.0.0 <14.0.0`, it only installs `vinkla/hashids` v13.x — which itself only supports `illuminate/contracts ^12.0` (Laravel 12). This means the package cannot actually be installed under Laravel 13 despite the framework constraint appearing to allow it.

## Fix

Widen the constraint to `^13.0.0|^14.0.0` so that:
- Laravel 9–12 users continue to get `vinkla/hashids` v13.x
- Laravel 13 users get `vinkla/hashids` v14.x, which supports `illuminate/contracts ^13.x`